### PR TITLE
src/common.h: include stdlib.h - fixes build on FreeBSD

### DIFF
--- a/src/common.hpp
+++ b/src/common.hpp
@@ -2,4 +2,5 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <assert.h>


### PR DESCRIPTION
Builds and works fine on FreeBSD 10.1/amd64 with this small tweak, using CXX=clang++.  Also build tested on Debian stable/x86-64.
