### PR TITLE
fix V523 with PVS-Studio

### DIFF
--- a/src/encoding.cpp
+++ b/src/encoding.cpp
@@ -126,18 +126,8 @@ template <bool swap> struct UTF32Decoder
 		{
 			uint32_t lead = swap ? endianSwap(*data) : *data;
 
-			// U+0000..U+FFFF
-			if (lead < 0x10000)
-			{
-				result = pred(result, lead);
-				data += 1;
-			}
-			// U+10000..U+10FFFF
-			else
-			{
-				result = pred(result, lead);
-				data += 1;
-			}
+			result = pred(result, lead);
+			data += 1;
 		}
 
 		return result;


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warning: [V523](https://www.viva64.com/en/w/v523/) The 'then' statement is equivalent to the 'else' statement.

(https://github.com/zeux/qgrep/blob/master/src/encoding.cpp#L136)

