### PR TITLE
fixed alloc-dealloc mismatch

### DIFF
--- a/src/blockpool.cpp
+++ b/src/blockpool.cpp
@@ -24,7 +24,7 @@ BlockPool::~BlockPool()
 std::shared_ptr<char> BlockPool::allocate(size_t size)
 {
 	if (size > blockSize)
-		return std::shared_ptr<char>(new char[size]);
+		return std::shared_ptr<char>(new char[size], std::default_delete<char[]>());
 
 	std::lock_guard<std::mutex> lock(mutex);
 


### PR DESCRIPTION
std::shared_ptr<char>(new char[size]); creates an alloc-dealloc mismatch as the shared pointer automatically calls delete (and not delete[] ). The shared pointer will now call delete[].