### PR TITLE
consider the second argument of qgrep#open in vimscript to be the input

### DIFF
--- a/vim/autoload/qgrep.vim
+++ b/vim/autoload/qgrep.vim
@@ -314,8 +314,12 @@ function! s:open(args)
 
     " get state from history or from sensible defaults
     let mode = empty(a:args) ? g:qgrep.mode : a:args[0]
-    let state = has_key(s:history, mode) ? copy(s:history[mode]) : {'cursor': 0, 'input': '', 'line': 0, 'results': [], 'mode': mode, 'config': {}}
+    let state = (has_key(s:history, mode)) && (len(a:args) <= 1) ? copy(s:history[mode]) : {'cursor': 0, 'input': '', 'line': 0, 'results': [], 'mode': mode, 'config': {}}
     let s:state = state
+
+    if len(a:args) > 1
+        let state.input = a:args[1]
+    endif
 
     " make sure that any existing input triggers the 'selected' state
     let state.cursor = len(state.input) ? -1 : 0


### PR DESCRIPTION
I was looking for some vim command to automatically search with qgrep for the word under the cursor. This was a pain to do with normal! and execute, so I looked if it was possible to pass the command QgrepSearch some arguments. I'm still a noob in vimscript but didn't see a lot of use from the qgrep#open arguments, excepts from the first one which was the mode.

So I simply added a way to check if another second argument was provided, and if it is, consider it as the default first input.

With that change, it now because way easier to make vimscript command for qgrep. For example (tested on my side) : 

`:execute "QgrepSearch" expand("<cword>")`

launches qgrep with, as default input, the current word under the cursor. And you can go way crazier with that :)

I'm also a noob in PR, so tell me if there's something I could do better.