### PR TITLE
Use SIMD on ARM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,10 @@ ifeq ($(shell uname -p),x86_64)
 CCFLAGS+=-msse2 -DUSE_SSE2
 endif
 
+ifeq ($(shell uname -p),arm)
+CCFLAGS+=-DUSE_NEON
+endif
+
 ifeq ($(shell uname),Darwin)
 CCFLAGS+=-force_cpusubtype_ALL -mmacosx-version-min=10.7 -stdlib=libc++
 LDFLAGS+=-force_cpusubtype_ALL -mmacosx-version-min=10.7 -stdlib=libc++

--- a/src/casefold.hpp
+++ b/src/casefold.hpp
@@ -1,12 +1,8 @@
 // This file is part of qgrep and is distributed under the MIT license, see LICENSE.md
 #pragma once
 
-#ifdef USE_SSE2
-#include <emmintrin.h>
-#endif
-
-#ifdef USE_NEON
-#include <arm_neon.h>
+#if defined(USE_SSE2) || defined(USE_NEON)
+#include "charsimd.hpp"
 #endif
 
 const unsigned char kCaseFoldASCII[] =
@@ -34,7 +30,7 @@ inline char casefold(char ch)
 	return kCaseFoldASCII[static_cast<unsigned char>(ch)];
 }
 
-#if defined(USE_SSE2)
+#if defined(USE_SSE2) || defined(USE_NEON)
 inline void casefoldRange(char* dest, const char* begin, const char* end)
 {
 	if (end - begin < 64)
@@ -46,49 +42,18 @@ inline void casefoldRange(char* dest, const char* begin, const char* end)
 	else
 	{
 		// Shift 'A'..'Z' range ([65..90]) to [102..127] to use one signed comparison insn
-		__m128i shiftAmount = _mm_set1_epi8(127 - 'Z');
-		__m128i lowerBound = _mm_set1_epi8(127 - ('Z' - 'A') - 1);
-		__m128i upperBit = _mm_set1_epi8(0x20);
+		simd16 shiftAmount = simd_dup(127 - 'Z');
+		simd16 lowerBound = simd_dup(127 - ('Z' - 'A') - 1);
+		simd16 upperBit = simd_dup(0x20);
 
 		const char* i = begin;
 
 		for (; i + 16 < end; i += 16)
 		{
-			__m128i v = _mm_loadu_si128(reinterpret_cast<const __m128i*>(i));
-			__m128i upperMask = _mm_cmpgt_epi8(_mm_add_epi8(v, shiftAmount), lowerBound);
-			__m128i cfv = _mm_or_si128(v, _mm_and_si128(upperMask, upperBit));
-			_mm_storeu_si128(reinterpret_cast<__m128i*>(dest), cfv);
-			dest += 16;
-		}
-
-		for (; i != end; ++i)
-			*dest++ = casefold(*i);
-	}
-}
-#elif defined(USE_NEON)
-inline void casefoldRange(char* dest, const char* begin, const char* end)
-{
-	if (end - begin < 64)
-	{
-		// short string, don't bother optimizing
-		for (const char* i = begin; i != end; ++i)
-			*dest++ = casefold(*i);
-	}
-	else
-	{
-		// Shift 'A'..'Z' range ([65..90]) to [102..127] to use one signed comparison insn
-		int8x16_t shiftAmount = vdupq_n_s8(127 - 'Z');
-		int8x16_t lowerBound = vdupq_n_s8(127 - ('Z' - 'A') - 1);
-		int8x16_t upperBit = vdupq_n_s8(0x20);
-
-		const char* i = begin;
-
-		for (; i + 16 < end; i += 16)
-		{
-			int8x16_t v = vld1q_s8(reinterpret_cast<const int8_t*>(i));
-			int8x16_t upperMask = vcgtq_s8(vaddq_s8(v, shiftAmount), lowerBound);
-			int8x16_t cfv = vorrq_s8(v, vandq_s8(upperMask, upperBit));
-			vst1q_s8(reinterpret_cast<int8_t*>(dest), cfv);
+			simd16 v = simd_load(i);
+			simd16 upperMask = simd_cmpgt(simd_add(v, shiftAmount), lowerBound);
+			simd16 cfv = simd_or(v, simd_and(upperMask, upperBit));
+			simd_store(dest, cfv);
 			dest += 16;
 		}
 

--- a/src/charsimd.hpp
+++ b/src/charsimd.hpp
@@ -1,0 +1,86 @@
+// This file is part of qgrep and is distributed under the MIT license, see LICENSE.md
+#pragma once
+
+#include <stdint.h>
+
+#ifdef USE_SSE2
+#include <emmintrin.h>
+
+typedef __m128i simd16;
+
+inline simd16 simd_dup(char v)
+{
+	return _mm_set1_epi8(v);
+}
+
+inline simd16 simd_load(const void* p)
+{
+	return _mm_loadu_si128(static_cast<const __m128i*>(p));
+}
+
+inline void simd_store(void* p, simd16 v)
+{
+	_mm_storeu_si128(static_cast<__m128i*>(p), v);
+}
+
+inline simd16 simd_cmpgt(simd16 a, simd16 b)
+{
+	return _mm_cmpgt_epi8(a, b);
+}
+
+inline simd16 simd_add(simd16 a, simd16 b)
+{
+	return _mm_add_epi8(a, b);
+}
+
+inline simd16 simd_and(simd16 a, simd16 b)
+{
+	return _mm_and_si128(a, b);
+}
+
+inline simd16 simd_or(simd16 a, simd16 b)
+{
+	return _mm_or_si128(a, b);
+}
+#endif
+
+#ifdef USE_NEON
+#include <arm_neon.h>
+
+typedef uint8x16_t simd16;
+
+inline simd16 simd_dup(char v)
+{
+	return vdupq_n_s8(v);
+}
+
+inline simd16 simd_load(const void* p)
+{
+	return vld1q_s8(static_cast<const int8_t*>(p));
+}
+
+inline void simd_store(void* p, simd16 v)
+{
+	vst1q_s8(static_cast<int8_t*>(p), v);
+}
+
+inline simd16 simd_cmpgt(simd16 a, simd16 b)
+{
+	return vcgtq_s8(a, b);
+}
+
+inline simd16 simd_add(simd16 a, simd16 b)
+{
+	return vaddq_s8(a, b);
+}
+
+inline simd16 simd_and(simd16 a, simd16 b)
+{
+	return vandq_s8(a, b);
+}
+
+inline simd16 simd_or(simd16 a, simd16 b)
+{
+	return vorrq_s8(a, b);
+}
+#endif

--- a/src/charsimd.hpp
+++ b/src/charsimd.hpp
@@ -28,6 +28,11 @@ inline simd16 simd_cmpgt(simd16 a, simd16 b)
 	return _mm_cmpgt_epi8(a, b);
 }
 
+inline simd16 simd_cmpeq(simd16 a, simd16 b)
+{
+	return _mm_cmpeq_epi8(a, b);
+}
+
 inline simd16 simd_add(simd16 a, simd16 b)
 {
 	return _mm_add_epi8(a, b);
@@ -41,6 +46,11 @@ inline simd16 simd_and(simd16 a, simd16 b)
 inline simd16 simd_or(simd16 a, simd16 b)
 {
 	return _mm_or_si128(a, b);
+}
+
+inline int simd_movemask(simd16 v)
+{
+	return _mm_movemask_epi8(v);
 }
 #endif
 
@@ -69,6 +79,11 @@ inline simd16 simd_cmpgt(simd16 a, simd16 b)
 	return vcgtq_s8(a, b);
 }
 
+inline simd16 simd_cmpeq(simd16 a, simd16 b)
+{
+	return vceqq_s8(a, b);
+}
+
 inline simd16 simd_add(simd16 a, simd16 b)
 {
 	return vaddq_s8(a, b);
@@ -82,5 +97,29 @@ inline simd16 simd_and(simd16 a, simd16 b)
 inline simd16 simd_or(simd16 a, simd16 b)
 {
 	return vorrq_s8(a, b);
+}
+
+inline int simd_movemask(simd16 v)
+{
+	static const uint8_t maskv[16] = {1, 2, 4, 8, 16, 32, 64, 128, 1, 2, 4, 8, 16, 32, 64, 128};
+
+	uint8x16_t mask = vld1q_u8(maskv);
+	uint8x16_t masked = vandq_u8(mask, vreinterpretq_u8_s8(v));
+
+#ifdef __aarch64__
+	// aarch64 has horizontal sums; MSVC doesn't expose this via arm64_neon.h so this path is exclusive to clang/gcc
+	int mask0 = vaddv_u8(vget_low_u8(masked));
+	int mask1 = vaddv_u8(vget_high_u8(masked));
+#else
+	// we need horizontal sums of each half of masked, which can be done in 3 steps (yielding sums of sizes 2, 4, 8)
+	uint8x8_t sum1 = vpadd_u8(vget_low_u8(masked), vget_high_u8(masked));
+	uint8x8_t sum2 = vpadd_u8(sum1, sum1);
+	uint8x8_t sum3 = vpadd_u8(sum2, sum2);
+
+	int mask0 = vget_lane_u8(sum3, 0);
+	int mask1 = vget_lane_u8(sum3, 1);
+#endif
+
+	return mask0 | (mask1 << 8);
 }
 #endif

--- a/src/regex.cpp
+++ b/src/regex.cpp
@@ -257,7 +257,7 @@ public:
 
 		std::string prefix = getPrefix(re.get(), 128);
 
-	#ifdef USE_SSE2
+	#if defined(USE_SSE2) || defined(USE_NEON)
 		if (prefix.length() == 1)
 			matcher.reset(new LiteralMatcher1(prefix.c_str()));
 		else if (prefix.length() > 1)


### PR DESCRIPTION
This change converts existing SIMD implementations to use a SIMD wrapper (charsimd.hpp) and implements a version of that wrapper for ARM/NEON.