### PR TITLE
Fix long file splitting so that it doesn't leave empty parts

### DIFF
--- a/src/build.cpp
+++ b/src/build.cpp
@@ -491,9 +491,12 @@ static void flushChunk(BuildContext* context, size_t size)
 		}
 		else
 		{
-			// last file does not fit completely, store some part of it and put the remaining lines back into pending list
+			// last file may not fit completely, store some part of it and put the remaining lines back into pending list
 			appendChunkFilePrefix(chunk, file, remainingSize);
-			context->pendingFiles.emplace_front(file);
+
+			// we might have fully appended the file if it was one huge line, but usually there's a remainder to be processed later
+			if (file.contents.size())
+				context->pendingFiles.emplace_front(file);
 
 			// it's impossible to add any more files to this chunk without making it larger than requested
 			break;


### PR DESCRIPTION
When a file is very long (longer than chunk size) and doesn't have
newlines, when appending the prefix we'd append the entire file but then
queue the suffix which is empty (size=0) but has a startLine=1; this
results in an extra 0-byte part of the file with startLine=1, and trying
to append that chunk causes an assertion later in the build process.

Also cleans up the processing of the first file in a chunk to make the logic
easier to follow.

Fixes #17.