### PR TITLE
Add an 'interactive' command that combines watch with search/files

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -344,6 +344,7 @@ void printHelp(Output* output, bool extended)
 "  qgrep update <project-list>\n"
 "  qgrep search <project-list> <search-options> <query>\n"
 "  qgrep watch <project-list>\n"
+"  qgrep intercative <project-list>\n"
 "  qgrep help\n", kVersion);
 
     if (extended)
@@ -382,7 +383,9 @@ void printHelp(Output* output, bool extended)
 "\n"
 "<search-options> can include additional options for files/filter commands:\n"
 "  fp - search in file paths (default)  fn - search in file names\n"
-"  ff - fuzzy search with ranking       fs - search for space-delimited words\n");
+"  ff - fuzzy search with ranking       fs - search for space-delimited words\n"
+"\n"
+"in interactive mode, you can input 'search' and 'files' commands without a project list.\n");
 }
 
 void mainImpl(Output* output, int argc, const char** argv, const char* input, size_t inputSize)
@@ -443,7 +446,7 @@ void mainImpl(Output* output, int argc, const char** argv, const char* input, si
 			std::vector<std::thread> threads;
 
 			for (size_t i = 0; i < paths.size(); ++i)
-				threads.emplace_back([=] { watchProject(output, paths[i].c_str()); });
+				threads.emplace_back([=] { watchProject(output, paths[i].c_str(), false); });
 
 			for (auto& t: threads)
 				t.join();
@@ -456,6 +459,40 @@ void mainImpl(Output* output, int argc, const char** argv, const char* input, si
 
 			for (size_t i = 0; i < paths.size(); ++i)
 				appendChanges(output, paths[i].c_str(), changes);
+		}
+		else if (argc > 2 && strcmp(argv[1], "interactive") == 0)
+		{
+			std::vector<std::string> paths = getProjectPaths(argv[2]);
+			std::vector<std::thread> threads;
+
+			for (size_t i = 0; i < paths.size(); ++i)
+				threads.emplace_back([=] { watchProject(output, paths[i].c_str(), true); });
+
+			std::vector<const char*> intArgv(argv, argv + argc);
+			std::string intInput;
+			intArgv.push_back(""); // Used later to place the input
+
+			char buf[1024];
+			while (fgets(buf, 1024, stdin))
+			{
+				if (strncmp(buf, "search ", 7) == 0)
+				{
+					intArgv[1] = "search";
+					intInput = std::string(buf + 7, buf + strlen(buf) - 1);
+					intArgv.back() = intInput.c_str();
+					processSearchCommand(output, intArgv.size(), &intArgv[0], searchProject);
+				}
+				else if (strncmp(buf, "files ", 6) == 0)
+				{
+					intArgv[1] = "files";
+					intInput = std::string(buf + 6, buf + strlen(buf) - 1);
+					intArgv.back() = intInput.c_str();
+					processSearchCommand(output, intArgv.size(), &intArgv[0], searchFiles);
+				}
+			}
+
+			for (auto& t : threads)
+				t.join();
 		}
 		else if (argc > 1 && strcmp(argv[1], "version") == 0)
 		{

--- a/src/watch.cpp
+++ b/src/watch.cpp
@@ -170,11 +170,12 @@ static void printStatistics(Output* output, const char* path, size_t fileCount)
 	output->print("%s: %d files changed\r", getProjectName(path).c_str(), int(fileCount));
 }
 
-void watchProject(Output* output, const char* path)
+void watchProject(Output* output, const char* path, bool interactive)
 {
 	WatchContext context = { output };
+	const char* lineEnd = interactive ? "\n" : "\r";
 
-    output->print("Watching %s:\n", path);
+	output->print("Watching %s:\n", path);
 
 	std::unique_ptr<ProjectGroup> group = parseProject(output, path);
 	if (!group)
@@ -182,11 +183,11 @@ void watchProject(Output* output, const char* path)
 
 	startWatchingRec(&context, group.get());
 
-	output->print("Scanning project...\r");
+	output->print("Scanning project...%s", lineEnd);
 
 	std::vector<FileInfo> files = getProjectGroupFiles(output, group.get());
 
-	output->print("Reading data pack...\r");
+	output->print("Reading data pack...%s", lineEnd);
 
 	std::vector<FileInfo> packFiles;
 	if (!getDataFileList(output, replaceExtension(path, ".qgd").c_str(), packFiles))
@@ -286,7 +287,8 @@ void watchProject(Output* output, const char* path)
 		{
 			assert(writeNeeded);
 
-			printStatistics(output, path, changedFiles.size());
+			if (!interactive)
+				printStatistics(output, path, changedFiles.size());
 
 			if (writeChanges(path, changedFiles))
 			{

--- a/src/watch.hpp
+++ b/src/watch.hpp
@@ -3,4 +3,4 @@
 
 class Output;
 
-void watchProject(Output* output, const char* path);
+void watchProject(Output* output, const char* path, bool interactive);


### PR DESCRIPTION
Quite often I find myself refactoring the code and it doesn't feel great to run update command before each search.
While 'watch' command is available, it has to be setup in a separate console.

This PR introduces an 'ggrep interactive project' command that combines watch command with search (and files).
Now when you have a long session with different searches and code updates, you just launch the interactive mode and use 'search term' or 'files term'.

Drawbacks: additional search flags are not supported.