### PR TITLE
Flag for outputting match end column

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ These are the available search options:
     V - Visual Studio style formatting: slashes are replaced with backslashes
         and line number is printed in parentheses
     C - include column number in output
-    CE - include match starting and ending column numbers in output
+    CE - include starting and ending column numbers in output
     Lnumber - limit output to <number> lines
 
 For example, this command uses case-insensitive regex search with Visual Studio

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These are the available search options:
     V - Visual Studio style formatting: slashes are replaced with backslashes
         and line number is printed in parentheses
     C - include column number in output
+    CE - include match starting and ending column numbers in output
     Lnumber - limit output to <number> lines
 
 For example, this command uses case-insensitive regex search with Visual Studio

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -213,6 +213,11 @@ void parseSearchOptions(const char* opts, unsigned int& options, unsigned int& l
 
 		case 'C':
 			options |= SO_COLUMNNUMBER;
+			if (s[1] == 'E')
+			{
+				options |= SO_COLUMNNUMBEREND;
+				s++;
+			}
 			break;
 
 		case 'H':
@@ -371,7 +376,8 @@ void printHelp(Output* output, bool extended)
 
     if (extended)
         output->print(
-"  C - output match column number       L<num> - limit output to <num> lines\n"
+"  C - output match column number       CE - output match starting and ending column numbers\n"
+"  L<num> - limit output to <num> lines\n"
 "\n"
 "<search-options> can include flags for restricting searches to certain files:\n"
 "  fi<re> - only search in files with paths matching regex <re>\n"

--- a/src/search.hpp
+++ b/src/search.hpp
@@ -16,11 +16,12 @@ enum SearchOptions
 
 	SO_VISUALSTUDIO = 1 << 7,
 	SO_COLUMNNUMBER = 1 << 8,
+	SO_COLUMNNUMBEREND = 1 << 9,
 
-	SO_HIGHLIGHT = 1 << 9,
-	SO_HIGHLIGHT_MATCHES = 1 << 10,
+	SO_HIGHLIGHT = 1 << 10,
+	SO_HIGHLIGHT_MATCHES = 1 << 11,
 
-	SO_SUMMARY = 1 << 11
+	SO_SUMMARY = 1 << 12
 };
 
 unsigned int getRegexOptions(unsigned int options);


### PR DESCRIPTION
This PR introduces an extension for the 'C' flag - the 'CE' flag, which outputs both the starting column and the ending column

This will allow programmatically extracting the whole match range.