### PR TITLE
Fix build with GCC 13

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 
 #include <mutex>
 #include <chrono>
+#include <stdexcept>
 
 const char* kVersion = "1.3";
 


### PR DESCRIPTION
`<stdexcept>` now needs to be included explicitly.