### PR TITLE
Optimize project scanning on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ grepping (i.e. full-text searches using regular expressions) over a large set
 of files. Searches use the database which is a compressed and indexed copy
 of the source data, thus they are much faster compared to vanilla grep -R.
 
-qgrep runs on Windows (Vista+, XP is not supported), Linux and MacOS X.
-
 Basic setup
 -----------
 

--- a/src/fileutil_win.cpp
+++ b/src/fileutil_win.cpp
@@ -46,7 +46,7 @@ static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const
 	std::wstring query = path + std::wstring(L"/*");
 
 	WIN32_FIND_DATAW data;
-	HANDLE h = FindFirstFileW(query.c_str(), &data);
+	HANDLE h = FindFirstFileExW(query.c_str(), FindExInfoBasic, &data, FindExSearchNameMatch, NULL, FIND_FIRST_EX_LARGE_FETCH);
 
 	if (h == INVALID_HANDLE_VALUE)
 		return false;


### PR DESCRIPTION
We were using FindFirstFileW instead of FindFirstFileExW, which provides two optimization opportunities for folder scanning:

- Specifying FindExInfoBasic avoids computing short file names (cAlternativeFileName), which we never use
- Specifying FIND_FIRST_EX_LARGE_FETCH increases the internal buffer sizes used for reading file entries

When folder hierarchy is cached (hot), the first optimization improves scan performance by ~10%. When folder hierarchy is read from disk (cold), the second optimization improves scan performance by ~25%. The numbers are measured on Windows 11 / Samsung 970 EVO / x64 on Linux kernel source tree (65k files).

Note: both flags are not supported on Windows XP/Vista, but they are supported on Windows 7+.