### PR TITLE
Add directory filter callback to traverseDirectory

### DIFF
--- a/src/fileutil.cpp
+++ b/src/fileutil.cpp
@@ -63,6 +63,11 @@ bool traverseFileNeeded(const char* name)
 	return true;
 }
 
+bool passthroughDirectoryFilter(const char* name)
+{
+	return true;
+}
+
 void joinPaths(std::string& buf, const char* lhs, const char* rhs)
 {
 	buf = lhs;

--- a/src/fileutil.hpp
+++ b/src/fileutil.hpp
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback);
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directoryFilter);
 bool traverseFileNeeded(const char* name);
 bool passthroughDirectoryFilter(const char* name);
 

--- a/src/fileutil.hpp
+++ b/src/fileutil.hpp
@@ -6,8 +6,9 @@
 
 #include <stdio.h>
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback);
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback);
 bool traverseFileNeeded(const char* name);
+bool passthroughDirectoryFilter(const char* name);
 
 void createDirectory(const char* path);
 void createPath(const char* path);

--- a/src/fileutil_posix.cpp
+++ b/src/fileutil_posix.cpp
@@ -21,7 +21,7 @@
 #include <CoreServices/CoreServices.h>
 #endif
 
-static bool traverseDirectoryRec(const char* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
+static bool traverseDirectoryRec(const char* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directoryFilter)
 {
 	int fd = open(path, O_DIRECTORY);
 	DIR* dir = fdopendir(fd);
@@ -65,8 +65,8 @@ static bool traverseDirectoryRec(const char* path, const char* relpath, const st
 
 			if (type == DT_DIR)
 			{
-				if (directory_filter_callback(relbuf.c_str()))
-					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directory_filter_callback);
+				if (directoryFilter(relbuf.c_str()))
+					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directoryFilter);
 			}
 			else if (type == DT_REG)
 			{
@@ -84,9 +84,9 @@ static bool traverseDirectoryRec(const char* path, const char* relpath, const st
 	return true;
 }
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool(const char* name)>& directory_filter_callback)
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool(const char* name)>& directoryFilter)
 {
-	return traverseDirectoryRec(path, "", callback, directory_filter_callback);
+	return traverseDirectoryRec(path, "", callback, directoryFilter);
 }
 
 bool renameFile(const char* oldpath, const char* newpath)

--- a/src/fileutil_posix.cpp
+++ b/src/fileutil_posix.cpp
@@ -21,7 +21,7 @@
 #include <CoreServices/CoreServices.h>
 #endif
 
-static bool traverseDirectoryRec(const char* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback)
+static bool traverseDirectoryRec(const char* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
 {
 	int fd = open(path, O_DIRECTORY);
 	DIR* dir = fdopendir(fd);
@@ -65,7 +65,8 @@ static bool traverseDirectoryRec(const char* path, const char* relpath, const st
 
 			if (type == DT_DIR)
 			{
-				traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback);
+				if (directory_filter_callback(relbuf.c_str()))
+					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directory_filter_callback);
 			}
 			else if (type == DT_REG)
 			{
@@ -83,9 +84,9 @@ static bool traverseDirectoryRec(const char* path, const char* relpath, const st
 	return true;
 }
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback)
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool(const char* name)>& directory_filter_callback)
 {
-	return traverseDirectoryRec(path, "", callback);
+	return traverseDirectoryRec(path, "", callback, directory_filter_callback);
 }
 
 bool renameFile(const char* oldpath, const char* newpath)

--- a/src/fileutil_win.cpp
+++ b/src/fileutil_win.cpp
@@ -41,7 +41,7 @@ static uint64_t combine(uint32_t hi, uint32_t lo)
 	return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
-static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback)
+static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
 {
 	std::wstring query = path + std::wstring(L"/*");
 
@@ -73,7 +73,8 @@ static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const
 				buf += '/';
 				buf += data.cFileName;
 
-				traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback);
+				if (directory_filter_callback(relbuf.c_str()))
+					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directory_filter_callback);
 			}
 			else
 			{
@@ -91,9 +92,9 @@ static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const
 	return true;
 }
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback)
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
 {
-	return traverseDirectoryRec(fromUtf8(path).c_str(), "", callback);
+	return traverseDirectoryRec(fromUtf8(path).c_str(), "", callback, directory_filter_callback);
 }
 
 bool renameFile(const char* oldpath, const char* newpath)

--- a/src/fileutil_win.cpp
+++ b/src/fileutil_win.cpp
@@ -41,7 +41,7 @@ static uint64_t combine(uint32_t hi, uint32_t lo)
 	return (static_cast<uint64_t>(hi) << 32) | lo;
 }
 
-static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
+static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directoryFilter)
 {
 	std::wstring query = path + std::wstring(L"/*");
 
@@ -73,8 +73,8 @@ static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const
 				buf += '/';
 				buf += data.cFileName;
 
-				if (directory_filter_callback(relbuf.c_str()))
-					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directory_filter_callback);
+				if (directoryFilter(relbuf.c_str()))
+					traverseDirectoryRec(buf.c_str(), relbuf.c_str(), callback, directoryFilter);
 			}
 			else
 			{
@@ -92,9 +92,9 @@ static bool traverseDirectoryRec(const wchar_t* path, const char* relpath, const
 	return true;
 }
 
-bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directory_filter_callback)
+bool traverseDirectory(const char* path, const std::function<void (const char* name, uint64_t mtime, uint64_t size)>& callback, const std::function<bool (const char* name)>& directoryFilter)
 {
-	return traverseDirectoryRec(fromUtf8(path).c_str(), "", callback, directory_filter_callback);
+	return traverseDirectoryRec(fromUtf8(path).c_str(), "", callback, directoryFilter);
 }
 
 bool renameFile(const char* oldpath, const char* newpath)


### PR DESCRIPTION
Evaluate exclusion rules during traversal so we can rule out entire subtrees without traversing into them instead of enumerating them exhaustively only to find that every single file inside them matches some subtree exclusion pattern.

This can be a massive time reduction on large projects that mix code- with non-code in the same directory tree. On one large game project, it reduced qgrep update time from nearly 400s down to 9s.