### PR TITLE
Minor build performance improvements

### DIFF
--- a/src/build.cpp
+++ b/src/build.cpp
@@ -191,12 +191,16 @@ static std::pair<size_t, unsigned int> skipByLines(const char* data, size_t data
 {
 	auto result = std::make_pair(0, 0);
 
-	for (size_t i = 0; i < dataSize; ++i)
-		if (data[i] == '\n')
-		{
-			result.first = i + 1;
-			result.second++;
-		}
+	while (const char* next = static_cast<const char*>(memchr(data, '\n', dataSize)))
+	{
+		next++; // skip \n
+
+		result.first += next - data;
+		result.second++;
+
+		dataSize -= next - data;
+		data = next;
+	}
 
 	return result;
 }


### PR DESCRIPTION
- Use memchr in skipByLines to optimize scanning
- Avoid redundant file copy when the file is newly allocated

On Linux kernel source tree with 16 workers, this gets total wall clock time for `qgrep build` down from 1.36s to 1.21s, although timing is noisy; both operations are done on the main thread so this effectively reduces the serialization.